### PR TITLE
Add url argument for conda channel mirrors

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ CACHED_CHANNELS = [
 def fetch_artifact_graph(channel, constraints, arch) -> ArtifactGraph:
     constraints = constraints.split(",")
     channel = channel.split(",")
-    ag = get_artifact_graph(channel, arch, constraints)
+    ag = get_artifact_graph(URL, channel, arch, constraints)
     return ag
 
 
@@ -42,9 +42,9 @@ def repodata_json_bz2(channel, constraints, arch):
     return ag.repodata_json_bzip()
 
 
-async def warm_cache(loop, channel, arch):
+async def warm_cache(loop, url, channel, arch):
     while True:
-        await loop.run_in_executor(None, get_repo_data, channel, arch)
+        await loop.run_in_executor(None, get_repo_data, url, channel, arch)
         await asyncio.sleep(30)
 
 
@@ -129,7 +129,10 @@ if __name__ == "__main__":
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", default=20124, type=int)
     parser.add_argument("--reload", action="store_true")
+    parser.add_argument("--url", default="https://conda.anaconda.org/")
     args = parser.parse_args()
+
+    URL = args.url.rstrip('/')
 
     try:
         if in_container() and args.host == "127.0.0.1":
@@ -143,6 +146,6 @@ if __name__ == "__main__":
     loop = asyncio.get_event_loop()
     # Start the background worker to run through all the channels
     for channel, arch in CACHED_CHANNELS:
-        loop.create_task(warm_cache(loop, [channel], arch))
+        loop.create_task(warm_cache(loop, URL, [channel], arch))
 
     app.run(host=args.host, port=args.port, use_reloader=args.reload, loop=loop)

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ CACHED_CHANNELS = [
 def fetch_artifact_graph(channel, constraints, arch) -> ArtifactGraph:
     constraints = constraints.split(",")
     channel = channel.split(",")
-    ag = get_artifact_graph(channel, arch, constraints, BASE_URL)
+    ag = get_artifact_graph(channel, arch, constraints, base_url)
     return ag
 
 
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     parser.add_argument("--base-url", default="https://conda.anaconda.org/")
     args = parser.parse_args()
 
-    BASE_URL = args.base_url.rstrip('/')
+    base_url = args.base_url.rstrip('/')
 
     try:
         if in_container() and args.host == "127.0.0.1":
@@ -146,6 +146,6 @@ if __name__ == "__main__":
     loop = asyncio.get_event_loop()
     # Start the background worker to run through all the channels
     for channel, arch in CACHED_CHANNELS:
-        loop.create_task(warm_cache(loop, [channel], arch, BASE_URL))
+        loop.create_task(warm_cache(loop, [channel], arch, base_url))
 
     app.run(host=args.host, port=args.port, use_reloader=args.reload, loop=loop)

--- a/app.py
+++ b/app.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     parser.add_argument("--base-url", default="https://conda.anaconda.org/")
     args = parser.parse_args()
 
-    base_url = args.base_url.rstrip('/')
+    base_url = args.base_url
 
     try:
         if in_container() and args.host == "127.0.0.1":

--- a/graph.py
+++ b/graph.py
@@ -24,7 +24,7 @@ logger = getLogger(__name__)
 
 
 def build_repodata_graph(
-    repodata: dict, arch: str, url_prefix: str
+        repodata: dict, arch: str, url_prefix: str
 ) -> networkx.DiGraph:
     G = networkx.DiGraph()
     for p, v in repodata["packages"].items():
@@ -144,14 +144,14 @@ class FusedRepoData:
         return f"FusedRepoData([{''.join(self.component_channels)}], {self.arch})"
 
 
-def get_repo_data(url: str, channel: typing.List[str], arch: str) -> FusedRepoData:
+def get_repo_data(channel: typing.List[str], arch: str, base_url: str = "https://conda.anaconda.org/") -> FusedRepoData:
     repodatas = []
     RawRepoData._expire()
     for c in channel:
         key = (c, arch)
         # TODO: This should happen in parallel
         if key not in RawRepoData._cache:
-            RawRepoData._cache[key] = RawRepoData(url, c, arch)
+            RawRepoData._cache[key] = RawRepoData(c, arch, base_url)
         repodatas.append(RawRepoData._cache[key])
     return FusedRepoData(repodatas, arch)
 
@@ -183,19 +183,18 @@ def get_blacklist(blacklist_name, channel, arch):
 
 
 class ArtifactGraph:
-
     _ttl = 600
     _artifact_graph_cache = TTLCache(100, ttl=_ttl)
     _last_expiry = time.monotonic()
 
-    def __init__(self, url, channel, arch, constraints):
-        self.url = url
+    def __init__(self, channel, arch, constraints, base_url="https://conda.anaconda.org/"):
+        self.base_url = base_url
         self.channel = channel
         self.arch = arch
         self.constraints = constraints
 
         # TODO: These should run in parallel
-        self.raw = get_repo_data(url, channel, arch)
+        self.raw = get_repo_data(channel, arch, base_url)
 
         # TODO: Since solving the artifact graph happens twice for a given conda operation, once for arch and once for
         #       noarch we need to treat the noarch channel here as an arch channel.
@@ -203,9 +202,9 @@ class ArtifactGraph:
         #       In the future it may be wiser to just store the whole are collectively.
 
         if arch != "noarch":
-            self.noarch = get_repo_data(url, channel, "noarch")
+            self.noarch = get_repo_data(channel, "noarch", base_url)
         else:
-            self.noarch = get_repo_data(url, channel, "linux-64")
+            self.noarch = get_repo_data(channel, "linux-64", base_url)
 
         self.package_constraints, self.functional_constraints = parse_constraints(
             constraints
@@ -362,7 +361,7 @@ class ArtifactGraph:
 
 
 def get_artifact_graph(
-    url: str, channel: typing.List[str], arch: str, constraints
+        channel: typing.List[str], arch: str, constraints, base_url: str = "https://conda.anaconda.org/"
 ) -> ArtifactGraph:
     if isinstance(constraints, str):
         constraints = [constraints]
@@ -370,5 +369,5 @@ def get_artifact_graph(
     key = (tuple(channel), arch, tuple(sorted(constraints)))
     agcache = ArtifactGraph.artifact_graph_cache()
     if key not in agcache:
-        agcache[key] = ArtifactGraph(url, channel, arch, constraints)
+        agcache[key] = ArtifactGraph(channel, arch, constraints, base_url)
     return agcache[key]

--- a/graph.py
+++ b/graph.py
@@ -96,9 +96,9 @@ class RawRepoData:
         if '{channel}' in base_url and '{arch}' in base_url:
             url_prefix = base_url.format(channel=channel, arch=arch)
         elif '{channel}' in base_url:
-            url_prefix = base_url.format(channel=channel) + f"/{arch}"
+            url_prefix = base_url.format(channel=channel).rstrip('/') + f"/{arch}"
         else:
-            url_prefix = f"{base_url}/{channel}/{arch}"
+            url_prefix = f"{base_url.rstrip('/')}/{channel}/{arch}"
         repodata_url = f"{url_prefix}/repodata.json.bz2"
         data = requests.get(repodata_url)
         repodata = json.loads(bz2.decompress(data.content))

--- a/graph.py
+++ b/graph.py
@@ -88,17 +88,17 @@ class RawRepoData:
     _cache = TTLCache(100, ttl=_ttl)
     _last_expiry = time.monotonic()
 
-    def __init__(self, url: str, channel: str, arch: str = "linux-64", ttl=600):
+    def __init__(self, channel: str, arch: str = "linux-64", base_url: str = "https://conda.anaconda.org/", ttl=600):
         # setup cache
         self.ttl = ttl
         # normal seetings
         logger.info(f"RETRIEVING: {channel}, {arch}")
-        if '{channel}' in url and '{arch}' in url:
-            url_prefix = url.format(channel=channel, arch=arch)
-        elif '{channel}' in url:
-            url_prefix = url.format(channel=channel) + f"/{arch}"
+        if '{channel}' in base_url and '{arch}' in base_url:
+            url_prefix = base_url.format(channel=channel, arch=arch)
+        elif '{channel}' in base_url:
+            url_prefix = base_url.format(channel=channel) + f"/{arch}"
         else:
-            url_prefix = f"{url}/{channel}/{arch}"
+            url_prefix = f"{base_url}/{channel}/{arch}"
         repodata_url = f"{url_prefix}/repodata.json.bz2"
         data = requests.get(repodata_url)
         repodata = json.loads(bz2.decompress(data.content))


### PR DESCRIPTION
Would like to talk about `url` argument name (I think there is probably a better name) and what testing needs to be done.

I realized the use case is more complicated than I first thought. Our mirror follows the pattern `http://internal.url.com/conda-forge-remote` so this PR allows `python app.py --url https://internal.url.com` and then appends `channel` and `arch` or `python app.py --url https://internal.url.com/{channel}-remote/` or `python app.py --url https://internal.url.com/{channel}-remote/{arch}` in case the channel and/or arch are embedded in the middle of the url.

I have manually proven that this will work on linux using the following:

`$ python --url https://internal.url.com/{channel}-remote/`

in another terminal

`$ conda create --name metachannel-test python=3.7 pandas -c http://127.0.0.1:20124/conda-forge/pandas`