### PR TITLE
Add proper support for `defaults` channel from conda-forge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # Rever
 rever/
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 This is a small little web application to behave like a conda channel but 
-with constraints.  
+with user-specified constraints.  
 
-By doing this you can add a small conda-forge channel that has a limited number of edges
+By doing this you can add a small conda channel that has a limited number of packages.
 
 There is a hosted version of metachannel provided at https://metachannel.conda-forge.org
 
@@ -16,7 +16,19 @@ https://metachannel.conda-forge.org/conda-forge/pandas,ipython,scikit-learn
 This is a channel that contains pandas, ipython and scikit-learn (and all of their dependencies),
 and nothing else.
 
+## Recommended usage with conda-forge
 
+Presently metachannel is best used when creating *new* environments.  For example
+
+```bash
+conda create --override-channels \
+      -c https://metachannel.conda-forge.org/defaults,conda-forge/pandas \
+      'pandas>=0.24' 
+```
+
+This will function similarly to `strict` channel priority in conda, except it will fuse the 
+channels remotely and constrain the list of packages to be those that pandas requires to
+be installed.
 
 ## Advanced features
 
@@ -29,7 +41,8 @@ e.g.
 
 ```bash
 $ conda search --override-channels \
-      -c https://metachannel.conda-forge.org/conda-forge/python, 'python=3.6.1'
+      -c https://metachannel.conda-forge.org/conda-forge/python \
+      'python=3.6.1'
 
 python                    3.6.1               0  conda-forge/python
 python                    3.6.1               1  conda-forge/python
@@ -51,7 +64,7 @@ https://metachannel.conda-forge.org/<CHANNELA>,<CHANNELB>/<CONSTRAINTS>
 ```
 
 This will function like a composite of these two channels.  Packages that exist in channel `B` will
-supercede those in channel `A` for *ALL* versions.  
+supercede those in channel `A` for *ALL* versions (just like strict channel priority).  
 
 Channels that contain non-urlsafe characters need to be url-escaped
 
@@ -76,4 +89,3 @@ $ conda search --override-channels -c https://metachannel.conda-forge.org/conda-
 
 The default blacklist that ships with conda-metachannel is one that removes all potential abi
 incompatible packages resulting from the compiler switchover from conda-forge.
-

--- a/app.py
+++ b/app.py
@@ -22,6 +22,10 @@ CACHED_CHANNELS = [
     ("conda-forge", "osx-64"),
     ("conda-forge", "linux-64"),
     ("conda-forge", "win-64"),
+    ("defaults", 'noarch'),
+    ("defaults", 'osx-64'),
+    ("defaults", 'linux-64'),
+    ("defaults", 'win-64'),
 ]
 
 

--- a/graph.py
+++ b/graph.py
@@ -390,7 +390,7 @@ def get_artifact_graph(
         if arch == "win-64":
             new_channel = [
                 "https://repo.anaconda.com/pkgs/main",
-                "https://repo.anaconda.com/pkgs/msys"
+                "https://repo.anaconda.com/pkgs/msys",
                 "https://repo.anaconda.com/pkgs/r",
             ]
         else:


### PR DESCRIPTION
This also adds in a hack to treat pip the same way that conda-forge does.
Fixes channel fusing to work as intended